### PR TITLE
bug fix autocomplete and improve js autocomplete initSelection

### DIFF
--- a/Annotation/Util.php
+++ b/Annotation/Util.php
@@ -92,14 +92,14 @@ class Util implements ConfigurationInterface
     public function __construct(array $data = array())
     {
         if (isset($data['autoComplete'])) {
-            if (!(array_key_exists('route', $data) && array_key_exists('targetSelector', $data) && array_key_exists('routeCallback', $data))) {
-                throw new \InvalidArgumentException('route, routeCallback dan targetSelector harus diset');
-            }
+           if (!(array_key_exists('route', $data['autoComplete']) && array_key_exists('targetSelector', $data['autoComplete']) && array_key_exists('routeCallback', $data['autoComplete']))) {
+             throw new \InvalidArgumentException('route, routeCallback dan targetSelector harus diset');
+           }
 
-            $this->autoComplete = true;
-            $this->route = $data['route'];
-            $this->targetSelector = $data['targetSelector'];
-            $this->routeCallback = $data['routeCallback'];
+           $this->autoComplete = true;
+           $this->route = $data['autoComplete']['route'];
+           $this->targetSelector = $data['autoComplete']['targetSelector'];
+           $this->routeCallback = $data['autoComplete']['routeCallback'];
         }
 
         if (isset($data['datePicker'])) {

--- a/Resources/views/Crud/new.html.twig
+++ b/Resources/views/Crud/new.html.twig
@@ -188,11 +188,15 @@
                         cache: true
                     },
                     initSelection : function (element, callback) {
-                        jQuery.ajax(Routing.generate('{{- ac_config['route_callback'] -}}', {id:  jQuery(element).val()}), {
-                            dataType: 'json'
-                        }).done(function(data) {
-                            callback(data);
-                        });
+                         var id = jQuery(element).val();
+                         if (!id) {
+                             return;
+                         }
+                         jQuery.ajax(Routing.generate('{{- ac_config['route_callback'] -}}', {id:  id}), {
+                             dataType: 'json'
+                         }).done(function(data) {
+                             callback(data);
+                         });
                     }
                 });
                 jQuery(document).on('select2:select', '.autocomplete', function (e) {


### PR DESCRIPTION
1. bug in util autoComplete should use array $data['autoComplete'] instead $data
2. initSelection in jquery autocomplete fired only element value is defined (set)